### PR TITLE
Error descriptions

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -20,18 +20,18 @@ impl Host {
     pub(crate) fn parse(node: Node) -> Result<Self, Error> {
         let scan_start_time = node
             .attribute("starttime")
-            .ok_or(Error::from("expected `starttime` attribute in `host` node"))
+            .ok_or_else(|| Error::from("expected `starttime` attribute in `host` node"))
             .and_then(|s| {
                 s.parse::<i64>()
-                    .or(Err(Error::from("failed to parse host start time")))
+                    .or_else(|_| Err(Error::from("failed to parse host start time")))
             })?;
 
         let scan_end_time = node
             .attribute("endtime")
-            .ok_or(Error::from("expected `endtime` attribute in `host` node"))
+            .ok_or_else(|| Error::from("expected `endtime` attribute in `host` node"))
             .and_then(|s| {
                 s.parse::<i64>()
-                    .or(Err(Error::from("failed to parse host end time")))
+                    .or_else(|_| Err(Error::from("failed to parse host end time")))
             })?;
 
         let mut ip_address = None;
@@ -49,10 +49,12 @@ impl Host {
             }
         }
 
-        let ip_address = ip_address.ok_or(Error::from("expected `address` node for host"))?;
-        let status = status.ok_or(Error::from("expected `status` node for host"))?;
-        let host_names = host_names.ok_or(Error::from("expected `address` node for host"))?;
-        let port_info = port_info.ok_or(Error::from("expected `address` node for host"))?;
+        let ip_address =
+            ip_address.ok_or_else(|| Error::from("expected `address` node for host"))?;
+        let status = status.ok_or_else(|| Error::from("expected `status` node for host"))?;
+        let host_names =
+            host_names.ok_or_else(|| Error::from("expected `address` node for host"))?;
+        let port_info = port_info.ok_or_else(|| Error::from("expected `address` node for host"))?;
 
         Ok(Host {
             scan_start_time,
@@ -67,10 +69,10 @@ impl Host {
 
 fn parse_address_node(node: Node) -> Result<IpAddr, Error> {
     node.attribute("addr")
-        .ok_or(Error::from("expected `addr` attribute in `address` node"))
+        .ok_or_else(|| Error::from("expected `addr` attribute in `address` node"))
         .and_then(|s| {
             s.parse::<IpAddr>()
-                .or(Err(Error::from("failed to parse IP address")))
+                .or_else(|_| Err(Error::from("failed to parse IP address")))
         })
 }
 
@@ -94,26 +96,23 @@ pub struct HostStatus {
 
 impl HostStatus {
     fn parse(node: Node) -> Result<Self, Error> {
-        let s = node.attribute("state").ok_or(Error::from(
-            "expected `state` attribute in `hoststatus` node",
-        ))?;
-        let state = HostState::from_str(s).or(Err(Error::from("failed to parse host state")))?;
+        let s = node
+            .attribute("state")
+            .ok_or_else(|| Error::from("expected `state` attribute in `hoststatus` node"))?;
+        let state =
+            HostState::from_str(s).or_else(|_| Err(Error::from("failed to parse host state")))?;
 
         let reason = node
             .attribute("reason")
-            .ok_or(Error::from(
-                "expected `reason` attribute in `hoststatus` node",
-            ))?
+            .ok_or_else(|| Error::from("expected `reason` attribute in `hoststatus` node"))?
             .to_string();
 
         let reason_ttl = node
             .attribute("reason_ttl")
-            .ok_or(Error::from(
-                "expected `reason_ttl` attribute in `hoststatus` node",
-            ))
+            .ok_or_else(|| Error::from("expected `reason_ttl` attribute in `hoststatus` node"))
             .and_then(|s| {
                 s.parse::<u8>()
-                    .or(Err(Error::from("failed to parse `reason_ttl`")))
+                    .or_else(|_| Err(Error::from("failed to parse `reason_ttl`")))
             })?;
 
         Ok(HostStatus {
@@ -154,15 +153,14 @@ impl Hostname {
     fn parse(node: Node) -> Result<Self, Error> {
         let name = node
             .attribute("name")
-            .ok_or(Error::from("expected `name` attribute in `hostname` node"))?
+            .ok_or_else(|| Error::from("expected `name` attribute in `hostname` node"))?
             .to_string();
 
         let s = node
             .attribute("type")
-            .ok_or(Error::from("expected `type` attribute in `hostname` node"))?;
-        let source = HostnameType::from_str(s).or(Err(Error::from(
-            "expected `source` attribute in `address` node",
-        )))?;
+            .ok_or_else(|| Error::from("expected `type` attribute in `hostname` node"))?;
+        let source = HostnameType::from_str(s)
+            .or_else(|_| Err(Error::from("expected `source` attribute in `address` node")))?;
 
         Ok(Hostname { name, source })
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -20,13 +20,19 @@ impl Host {
     pub(crate) fn parse(node: Node) -> Result<Self, Error> {
         let scan_start_time = node
             .attribute("starttime")
-            .ok_or(Error::InvalidNmapOutput)
-            .and_then(|s| s.parse::<i64>().or(Err(Error::InvalidNmapOutput)))?;
+            .ok_or(Error::from("expected `starttime` attribute in `host` node"))
+            .and_then(|s| {
+                s.parse::<i64>()
+                    .or(Err(Error::from("failed to parse host start time")))
+            })?;
 
         let scan_end_time = node
             .attribute("endtime")
-            .ok_or(Error::InvalidNmapOutput)
-            .and_then(|s| s.parse::<i64>().or(Err(Error::InvalidNmapOutput)))?;
+            .ok_or(Error::from("expected `endtime` attribute in `host` node"))
+            .and_then(|s| {
+                s.parse::<i64>()
+                    .or(Err(Error::from("failed to parse host end time")))
+            })?;
 
         let mut ip_address = None;
         let mut status = None;
@@ -43,10 +49,10 @@ impl Host {
             }
         }
 
-        let ip_address = ip_address.ok_or(Error::InvalidNmapOutput)?;
-        let status = status.ok_or(Error::InvalidNmapOutput)?;
-        let host_names = host_names.ok_or(Error::InvalidNmapOutput)?;
-        let port_info = port_info.ok_or(Error::InvalidNmapOutput)?;
+        let ip_address = ip_address.ok_or(Error::from("expected `address` node for host"))?;
+        let status = status.ok_or(Error::from("expected `status` node for host"))?;
+        let host_names = host_names.ok_or(Error::from("expected `address` node for host"))?;
+        let port_info = port_info.ok_or(Error::from("expected `address` node for host"))?;
 
         Ok(Host {
             scan_start_time,
@@ -61,8 +67,11 @@ impl Host {
 
 fn parse_address_node(node: Node) -> Result<IpAddr, Error> {
     node.attribute("addr")
-        .ok_or(Error::InvalidNmapOutput)
-        .and_then(|s| s.parse::<IpAddr>().or(Err(Error::InvalidNmapOutput)))
+        .ok_or(Error::from("expected `addr` attribute in `address` node"))
+        .and_then(|s| {
+            s.parse::<IpAddr>()
+                .or(Err(Error::from("failed to parse IP address")))
+        })
 }
 
 fn parse_hostnames_node(node: Node) -> Result<Vec<Hostname>, Error> {
@@ -85,18 +94,27 @@ pub struct HostStatus {
 
 impl HostStatus {
     fn parse(node: Node) -> Result<Self, Error> {
-        let s = node.attribute("state").ok_or(Error::InvalidNmapOutput)?;
-        let state = HostState::from_str(s).or(Err(Error::InvalidNmapOutput))?;
+        let s = node.attribute("state").ok_or(Error::from(
+            "expected `state` attribute in `hoststatus` node",
+        ))?;
+        let state = HostState::from_str(s).or(Err(Error::from("failed to parse host state")))?;
 
         let reason = node
             .attribute("reason")
-            .ok_or(Error::InvalidNmapOutput)?
+            .ok_or(Error::from(
+                "expected `reason` attribute in `hoststatus` node",
+            ))?
             .to_string();
 
         let reason_ttl = node
             .attribute("reason_ttl")
-            .ok_or(Error::InvalidNmapOutput)
-            .and_then(|s| s.parse::<u8>().or(Err(Error::InvalidNmapOutput)))?;
+            .ok_or(Error::from(
+                "expected `reason_ttl` attribute in `hoststatus` node",
+            ))
+            .and_then(|s| {
+                s.parse::<u8>()
+                    .or(Err(Error::from("failed to parse `reason_ttl`")))
+            })?;
 
         Ok(HostStatus {
             state,
@@ -136,11 +154,15 @@ impl Hostname {
     fn parse(node: Node) -> Result<Self, Error> {
         let name = node
             .attribute("name")
-            .ok_or(Error::InvalidNmapOutput)?
+            .ok_or(Error::from("expected `name` attribute in `hostname` node"))?
             .to_string();
 
-        let s = node.attribute("type").ok_or(Error::InvalidNmapOutput)?;
-        let source = HostnameType::from_str(s).or(Err(Error::InvalidNmapOutput))?;
+        let s = node
+            .attribute("type")
+            .ok_or(Error::from("expected `type` attribute in `hostname` node"))?;
+        let source = HostnameType::from_str(s).or(Err(Error::from(
+            "expected `source` attribute in `address` node",
+        )))?;
 
         Ok(Hostname { name, source })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,14 @@ use crate::host::Host;
 pub enum Error {
     #[error("error parsing file as XML document")]
     XmlError(#[from] roxmltree::Error),
-    #[error("file is not an Nmap XML output")]
-    InvalidNmapOutput,
+    #[error("error parsing Nmap XML output: {0}")]
+    InvalidNmapOutput(String),
+}
+
+impl From<&str> for Error {
+    fn from(s: &str) -> Self {
+        Self::InvalidNmapOutput(s.to_string())
+    }
 }
 
 ///Root structure of a Nmap scan result.
@@ -54,13 +60,16 @@ impl NmapResults {
         let doc = Document::parse(&xml)?;
         let root_element = doc.root_element();
         if root_element.tag_name().name() != "nmaprun" {
-            return Err(Error::InvalidNmapOutput);
+            return Err(Error::from("expected `nmaprun` root tag"));
         }
 
         let scan_start_time = root_element
             .attribute("start")
-            .ok_or(Error::InvalidNmapOutput)
-            .and_then(|s| s.parse::<i64>().or(Err(Error::InvalidNmapOutput)))?;
+            .ok_or(Error::from("expected start time attribute"))
+            .and_then(|s| {
+                s.parse::<i64>()
+                    .or(Err(Error::from("failed to parse start time")))
+            })?;
 
         let mut hosts: Vec<Host> = Vec::new();
         let mut scan_end_time = None;
@@ -75,7 +84,8 @@ impl NmapResults {
             }
         }
 
-        let scan_end_time = scan_end_time.ok_or(Error::InvalidNmapOutput)?;
+        let scan_end_time =
+            scan_end_time.ok_or(Error::from("expected scan_end_time in runstats"))?;
 
         Ok(NmapResults {
             hosts,
@@ -90,11 +100,14 @@ fn parse_runstats(node: Node) -> Result<i64, Error> {
         if child.tag_name().name() == "finished" {
             let finished = child
                 .attribute("time")
-                .ok_or(Error::InvalidNmapOutput)
-                .and_then(|s| s.parse::<i64>().or(Err(Error::InvalidNmapOutput)))?;
+                .ok_or(Error::from("expected `time` `runstats`.`finished`"))
+                .and_then(|s| {
+                    s.parse::<i64>()
+                        .or(Err(Error::from("failed to parse end time")))
+                })?;
             return Ok(finished);
         }
     }
 
-    Err(Error::InvalidNmapOutput)
+    Err(Error::from("expected `finished` tag in `runstats`"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //!The API is __not stable__ and is subject to breaking changes until the
 //!crate reaches 1.0. Use with care.
 use roxmltree::{Document, Node};
-use strum;
 
 pub mod host;
 pub mod port;
@@ -65,10 +64,10 @@ impl NmapResults {
 
         let scan_start_time = root_element
             .attribute("start")
-            .ok_or(Error::from("expected start time attribute"))
+            .ok_or_else(|| Error::from("expected start time attribute"))
             .and_then(|s| {
                 s.parse::<i64>()
-                    .or(Err(Error::from("failed to parse start time")))
+                    .or_else(|_| Err(Error::from("failed to parse start time")))
             })?;
 
         let mut hosts: Vec<Host> = Vec::new();
@@ -85,7 +84,7 @@ impl NmapResults {
         }
 
         let scan_end_time =
-            scan_end_time.ok_or(Error::from("expected scan_end_time in runstats"))?;
+            scan_end_time.ok_or_else(|| Error::from("expected scan_end_time in runstats"))?;
 
         Ok(NmapResults {
             hosts,
@@ -100,10 +99,10 @@ fn parse_runstats(node: Node) -> Result<i64, Error> {
         if child.tag_name().name() == "finished" {
             let finished = child
                 .attribute("time")
-                .ok_or(Error::from("expected `time` `runstats`.`finished`"))
+                .ok_or_else(|| Error::from("expected `time` `runstats`.`finished`"))
                 .and_then(|s| {
                     s.parse::<i64>()
-                        .or(Err(Error::from("failed to parse end time")))
+                        .or_else(|_| Err(Error::from("failed to parse end time")))
                 })?;
             return Ok(finished);
         }

--- a/src/port.rs
+++ b/src/port.rs
@@ -14,6 +14,7 @@ impl PortInfo {
         let mut ports = Vec::new();
 
         for child in node.children() {
+            #[allow(clippy::single_match)]
             match child.tag_name().name() {
                 "port" => ports.push(Port::parse(child)?),
                 _ => {}
@@ -36,16 +37,16 @@ impl Port {
     fn parse(node: Node) -> Result<Self, Error> {
         let s = node
             .attribute("protocol")
-            .ok_or(Error::from("expected `protocol` attribute in `port` node"))?;
-        let protocol =
-            PortProtocol::from_str(s).or(Err(Error::from("failed to parse port protocol")))?;
+            .ok_or_else(|| Error::from("expected `protocol` attribute in `port` node"))?;
+        let protocol = PortProtocol::from_str(s)
+            .or_else(|_| Err(Error::from("failed to parse port protocol")))?;
 
         let port_number = node
             .attribute("portid")
-            .ok_or(Error::from("expected `portid` attribute in `port` node"))
+            .ok_or_else(|| Error::from("expected `portid` attribute in `port` node"))
             .and_then(|s| {
                 s.parse::<u16>()
-                    .or(Err(Error::from("failed to parse port ID")))
+                    .or_else(|_| Err(Error::from("failed to parse port ID")))
             })?;
 
         let mut status = None;
@@ -59,9 +60,9 @@ impl Port {
             }
         }
 
-        let status = status.ok_or(Error::from("expected `state` attribute for port"))?;
+        let status = status.ok_or_else(|| Error::from("expected `state` attribute for port"))?;
         let service_info =
-            service_info.ok_or(Error::from("expected `state` attribute for port"))?;
+            service_info.ok_or_else(|| Error::from("expected `state` attribute for port"))?;
 
         Ok(Port {
             protocol,
@@ -95,20 +96,21 @@ impl PortStatus {
     fn parse(node: Node) -> Result<Self, Error> {
         let s = node
             .attribute("state")
-            .ok_or(Error::from("expected `state` attribute for port"))?;
-        let state = PortState::from_str(s).or(Err(Error::from("failed to parse port state")))?;
+            .ok_or_else(|| Error::from("expected `state` attribute for port"))?;
+        let state =
+            PortState::from_str(s).or_else(|_| Err(Error::from("failed to parse port state")))?;
 
         let reason = node
             .attribute("reason")
-            .ok_or(Error::from("expected `reason` attribute for port"))?
+            .ok_or_else(|| Error::from("expected `reason` attribute for port"))?
             .to_string();
 
         let reason_ttl = node
             .attribute("reason_ttl")
-            .ok_or(Error::from("expected `reason_ttl` attribute for port"))
+            .ok_or_else(|| Error::from("expected `reason_ttl` attribute for port"))
             .and_then(|s| {
                 s.parse::<u8>()
-                    .or(Err(Error::from("failed to parse port reason_ttl")))
+                    .or_else(|_| Err(Error::from("failed to parse port reason_ttl")))
             })?;
 
         Ok(PortStatus {
@@ -146,22 +148,22 @@ impl ServiceInfo {
     fn parse(node: Node) -> Result<Self, Error> {
         let name = node
             .attribute("name")
-            .ok_or(Error::from("expected `name` attribute for service"))?
+            .ok_or_else(|| Error::from("expected `name` attribute for service"))?
             .to_string();
 
         let confidence_level = node
             .attribute("conf")
-            .ok_or(Error::from("expected `conf` attribute for service"))
+            .ok_or_else(|| Error::from("expected `conf` attribute for service"))
             .and_then(|s| {
                 s.parse::<u8>()
-                    .or(Err(Error::from("failed to parse port reason_ttl")))
+                    .or_else(|_| Err(Error::from("failed to parse port reason_ttl")))
             })?;
 
         let s = node
             .attribute("method")
-            .ok_or(Error::from("expected `method` attribute for service"))?;
-        let method =
-            ServiceMethod::from_str(s).or(Err(Error::from("failed to parse service method")))?;
+            .ok_or_else(|| Error::from("expected `method` attribute for service"))?;
+        let method = ServiceMethod::from_str(s)
+            .or_else(|_| Err(Error::from("failed to parse service method")))?;
 
         Ok(ServiceInfo {
             name,

--- a/src/port.rs
+++ b/src/port.rs
@@ -34,13 +34,19 @@ pub struct Port {
 
 impl Port {
     fn parse(node: Node) -> Result<Self, Error> {
-        let s = node.attribute("protocol").ok_or(Error::InvalidNmapOutput)?;
-        let protocol = PortProtocol::from_str(s).or(Err(Error::InvalidNmapOutput))?;
+        let s = node
+            .attribute("protocol")
+            .ok_or(Error::from("expected `protocol` attribute in `port` node"))?;
+        let protocol =
+            PortProtocol::from_str(s).or(Err(Error::from("failed to parse port protocol")))?;
 
         let port_number = node
             .attribute("portid")
-            .ok_or(Error::InvalidNmapOutput)
-            .and_then(|s| s.parse::<u16>().or(Err(Error::InvalidNmapOutput)))?;
+            .ok_or(Error::from("expected `portid` attribute in `port` node"))
+            .and_then(|s| {
+                s.parse::<u16>()
+                    .or(Err(Error::from("failed to parse port ID")))
+            })?;
 
         let mut status = None;
         let mut service_info = None;
@@ -53,8 +59,9 @@ impl Port {
             }
         }
 
-        let status = status.ok_or(Error::InvalidNmapOutput)?;
-        let service_info = service_info.ok_or(Error::InvalidNmapOutput)?;
+        let status = status.ok_or(Error::from("expected `state` attribute for port"))?;
+        let service_info =
+            service_info.ok_or(Error::from("expected `state` attribute for port"))?;
 
         Ok(Port {
             protocol,
@@ -86,18 +93,23 @@ pub struct PortStatus {
 
 impl PortStatus {
     fn parse(node: Node) -> Result<Self, Error> {
-        let s = node.attribute("state").ok_or(Error::InvalidNmapOutput)?;
-        let state = PortState::from_str(s).or(Err(Error::InvalidNmapOutput))?;
+        let s = node
+            .attribute("state")
+            .ok_or(Error::from("expected `state` attribute for port"))?;
+        let state = PortState::from_str(s).or(Err(Error::from("failed to parse port state")))?;
 
         let reason = node
             .attribute("reason")
-            .ok_or(Error::InvalidNmapOutput)?
+            .ok_or(Error::from("expected `reason` attribute for port"))?
             .to_string();
 
         let reason_ttl = node
             .attribute("reason_ttl")
-            .ok_or(Error::InvalidNmapOutput)
-            .and_then(|s| s.parse::<u8>().or(Err(Error::InvalidNmapOutput)))?;
+            .ok_or(Error::from("expected `reason_ttl` attribute for port"))
+            .and_then(|s| {
+                s.parse::<u8>()
+                    .or(Err(Error::from("failed to parse port reason_ttl")))
+            })?;
 
         Ok(PortStatus {
             state,
@@ -134,16 +146,22 @@ impl ServiceInfo {
     fn parse(node: Node) -> Result<Self, Error> {
         let name = node
             .attribute("name")
-            .ok_or(Error::InvalidNmapOutput)?
+            .ok_or(Error::from("expected `name` attribute for service"))?
             .to_string();
 
         let confidence_level = node
             .attribute("conf")
-            .ok_or(Error::InvalidNmapOutput)
-            .and_then(|s| s.parse::<u8>().or(Err(Error::InvalidNmapOutput)))?;
+            .ok_or(Error::from("expected `conf` attribute for service"))
+            .and_then(|s| {
+                s.parse::<u8>()
+                    .or(Err(Error::from("failed to parse port reason_ttl")))
+            })?;
 
-        let s = node.attribute("method").ok_or(Error::InvalidNmapOutput)?;
-        let method = ServiceMethod::from_str(s).or(Err(Error::InvalidNmapOutput))?;
+        let s = node
+            .attribute("method")
+            .ok_or(Error::from("expected `method` attribute for service"))?;
+        let method =
+            ServiceMethod::from_str(s).or(Err(Error::from("failed to parse service method")))?;
 
         Ok(ServiceInfo {
             name,


### PR DESCRIPTION
Hi, I've changed the `InvalidNmapOutput` error variant to take a String and implemented `From<&str>` to return this variant. I did it this way because any parsing error indicates an invalid Nmap XML format, so it didn't make sense to have dedicated variants for host error, port error, etc. The From impl means that we can simply use `Error::from("str")` to make the code a little more concise.

After changing from `InvalidNmapOutput` to `Error::from()`, Clippy suggested using the `.or_else()` family instead of `.or()` to avoid calling `Error::from()` unnecessarily.

Fixes #1 