### PR TITLE
[WIP] Iterator over NmapResults

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -7,13 +7,19 @@ use strum_macros::{Display, EnumString};
 use crate::port::PortInfo;
 use crate::Error;
 
-pub struct Host {
+#[derive(Debug)]
+pub struct HostDetails {
     pub ip_address: IpAddr,
     pub status: HostStatus,
     pub host_names: Vec<Hostname>,
-    pub port_info: PortInfo,
     pub scan_start_time: i64,
     pub scan_end_time: i64,
+}
+
+#[derive(Debug)]
+pub struct Host {
+    pub host_details: HostDetails,
+    pub port_info: PortInfo,
 }
 
 impl Host {
@@ -56,12 +62,15 @@ impl Host {
             host_names.ok_or_else(|| Error::from("expected `address` node for host"))?;
         let port_info = port_info.ok_or_else(|| Error::from("expected `address` node for host"))?;
 
-        Ok(Host {
+        let host_details = HostDetails {
             scan_start_time,
             scan_end_time,
             ip_address,
             status,
             host_names,
+        };
+        Ok(Host {
+            host_details,
             port_info,
         })
     }
@@ -88,6 +97,7 @@ fn parse_hostnames_node(node: Node) -> Result<Vec<Hostname>, Error> {
     Ok(r)
 }
 
+#[derive(Debug)]
 pub struct HostStatus {
     pub state: HostState,
     pub reason: String,

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,11 +1,11 @@
 //!Host related structs and enums.
+use crate::port::PortInfo;
+use crate::Error;
 use roxmltree::Node;
 use std::net::IpAddr;
 use std::str::FromStr;
+use std::sync::Arc;
 use strum_macros::{Display, EnumString};
-
-use crate::port::PortInfo;
-use crate::Error;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct HostDetails {
@@ -18,8 +18,8 @@ pub struct HostDetails {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Host {
-    pub host_details: HostDetails,
-    pub port_info: PortInfo,
+    pub host_details: Arc<HostDetails>,
+    pub port_info: Arc<PortInfo>,
 }
 
 impl Host {
@@ -60,15 +60,16 @@ impl Host {
         let status = status.ok_or_else(|| Error::from("expected `status` node for host"))?;
         let host_names =
             host_names.ok_or_else(|| Error::from("expected `address` node for host"))?;
-        let port_info = port_info.ok_or_else(|| Error::from("expected `address` node for host"))?;
+        let port_info =
+            Arc::new(port_info.ok_or_else(|| Error::from("expected `address` node for host"))?);
 
-        let host_details = HostDetails {
+        let host_details = Arc::new(HostDetails {
             scan_start_time,
             scan_end_time,
             ip_address,
             status,
             host_names,
-        };
+        });
         Ok(Host {
             host_details,
             port_info,

--- a/src/host.rs
+++ b/src/host.rs
@@ -7,7 +7,7 @@ use strum_macros::{Display, EnumString};
 use crate::port::PortInfo;
 use crate::Error;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct HostDetails {
     pub ip_address: IpAddr,
     pub status: HostStatus,
@@ -16,7 +16,7 @@ pub struct HostDetails {
     pub scan_end_time: i64,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Host {
     pub host_details: HostDetails,
     pub port_info: PortInfo,
@@ -97,7 +97,7 @@ fn parse_hostnames_node(node: Node) -> Result<Vec<Hostname>, Error> {
     Ok(r)
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct HostStatus {
     pub state: HostState,
     pub reason: String,
@@ -133,7 +133,7 @@ impl HostStatus {
     }
 }
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(Clone, EnumString, Display, Debug, PartialEq)]
 pub enum HostState {
     #[strum(serialize = "up")]
     Up,
@@ -145,7 +145,7 @@ pub enum HostState {
     Skipped,
 }
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(Clone, EnumString, Display, Debug, PartialEq)]
 pub enum HostnameType {
     #[strum(serialize = "user", to_string = "User")]
     User,
@@ -153,7 +153,7 @@ pub enum HostnameType {
     Dns,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Hostname {
     pub name: String,
     pub source: HostnameType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //!crate reaches 1.0. Use with care.
 pub use crate::host::HostDetails;
 pub use crate::port::Port;
+use std::sync::Arc;
 
 use roxmltree::{Document, Node};
 
@@ -99,7 +100,7 @@ impl NmapResults {
 }
 
 impl IntoIterator for NmapResults {
-    type Item = (HostDetails, Port);
+    type Item = (Arc<HostDetails>, Port);
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -109,7 +110,7 @@ impl IntoIterator for NmapResults {
         // part static, then flatten to make a single iterator
 
         for host in &self.hosts {
-            for port in host.port_info.clone() {
+            for port in host.port_info.iter() {
                 results.push((host.host_details.clone(), port.clone()));
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,11 @@ impl NmapResults {
             scan_end_time,
         })
     }
+
+    /// Returns an iterator over the hosts present in the Nmap Scan
+    pub fn hosts(&self) -> std::slice::Iter <Host>{
+        self.hosts.iter()
+    }
 }
 
 impl IntoIterator for NmapResults {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ impl From<&str> for Error {
 }
 
 ///Root structure of a Nmap scan result.
+#[derive(Debug)]
 pub struct NmapResults {
     ///List of hosts in the Nmap scan.
     pub hosts: Vec<Host>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,12 @@ impl NmapResults {
     pub fn hosts(&self) -> std::slice::Iter <Host>{
         self.hosts.iter()
     }
+
+    /// Consumes self and returns an iterator over (Arc<HostDetails>, Port)
+    /// allowing iteration over the scanned ports.
+    pub fn iter(self) -> std::vec::IntoIter<(Arc<HostDetails>, Port)> {
+        self.into_iter()
+    }
 }
 
 impl IntoIterator for NmapResults {

--- a/src/port.rs
+++ b/src/port.rs
@@ -24,13 +24,9 @@ impl PortInfo {
 
         Ok(PortInfo { ports })
     }
-}
 
-impl IntoIterator for PortInfo {
-    type Item = Port;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.ports.into_iter()
+    pub fn iter(&self) -> std::slice::Iter<Port> {
+        self.ports.iter()
     }
 }
 

--- a/src/port.rs
+++ b/src/port.rs
@@ -5,6 +5,7 @@ use strum_macros::{Display, EnumString};
 
 use crate::Error;
 
+#[derive(Debug)]
 pub struct PortInfo {
     pub ports: Vec<Port>,
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -5,7 +5,7 @@ use strum_macros::{Display, EnumString};
 
 use crate::Error;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PortInfo {
     pub ports: Vec<Port>,
 }
@@ -26,7 +26,15 @@ impl PortInfo {
     }
 }
 
-#[derive(Debug, PartialEq)]
+impl IntoIterator for PortInfo {
+    type Item = Port;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.ports.into_iter()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Port {
     pub protocol: PortProtocol,
     pub port_number: u16,
@@ -74,7 +82,7 @@ impl Port {
     }
 }
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(Clone, EnumString, Display, Debug, PartialEq)]
 pub enum PortProtocol {
     #[strum(serialize = "ip")]
     Ip,
@@ -86,7 +94,7 @@ pub enum PortProtocol {
     Sctp,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PortStatus {
     pub state: PortState,
     pub reason: String,
@@ -122,7 +130,7 @@ impl PortStatus {
     }
 }
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(Clone, EnumString, Display, Debug, PartialEq)]
 pub enum PortState {
     #[strum(serialize = "open")]
     Open,
@@ -138,7 +146,7 @@ pub enum PortState {
     CloseFiltered,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ServiceInfo {
     pub name: String,
     pub confidence_level: u8,
@@ -174,7 +182,7 @@ impl ServiceInfo {
     }
 }
 
-#[derive(EnumString, Display, Debug, PartialEq)]
+#[derive(Clone, EnumString, Display, Debug, PartialEq)]
 pub enum ServiceMethod {
     #[strum(serialize = "table")]
     Table,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -33,28 +33,28 @@ fn end_time() {
 #[test]
 fn host_start_time() {
     let host = NMAP.hosts.get(0).unwrap();
-    assert_eq!(host.scan_start_time, 1588318812);
+    assert_eq!(host.host_details.scan_start_time, 1588318812);
 }
 
 #[test]
 fn host_end_time() {
     let host = NMAP.hosts.get(0).unwrap();
-    assert_eq!(host.scan_end_time, 1588318814);
+    assert_eq!(host.host_details.scan_end_time, 1588318814);
 }
 
 #[test]
 fn host_ip_address() {
     let host = NMAP.hosts.get(0).unwrap();
     let ip: std::net::IpAddr = "45.33.32.156".parse().unwrap();
-    assert_eq!(host.ip_address, ip);
+    assert_eq!(host.host_details.ip_address, ip);
 }
 
 #[test]
 fn host_status() {
     let host = NMAP.hosts.get(0).unwrap();
-    assert_eq!(host.status.reason, "echo-reply");
-    assert_eq!(host.status.reason_ttl, 53);
-    assert_eq!(host.status.state, host::HostState::Up);
+    assert_eq!(host.host_details.status.reason, "echo-reply");
+    assert_eq!(host.host_details.status.reason_ttl, 53);
+    assert_eq!(host.host_details.status.state, host::HostState::Up);
 }
 
 #[test]
@@ -72,8 +72,8 @@ fn host_hostnames() {
         source: host::HostnameType::Dns,
     });
 
-    assert!(!host.host_names.is_empty());
-    assert!(vectors_eq(&host.host_names, &expected));
+    assert!(!host.host_details.host_names.is_empty());
+    assert!(vectors_eq(&host.host_details.host_names, &expected));
 }
 
 #[test]

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -3,6 +3,7 @@ extern crate lazy_static;
 
 use nmap_xml_parser::host::*;
 use nmap_xml_parser::port::*;
+use std::sync::Arc;
 
 use nmap_xml_parser::{HostDetails, NmapResults, Port};
 use std::fs;
@@ -26,35 +27,37 @@ fn iter() {
     use PortState::*;
     use ServiceMethod::*;
     let nmap = NMAP.clone();
-    let vector: Vec<(HostDetails, Port)> = nmap.into_iter().collect();
+    let vector: Vec<(Arc<HostDetails>, Port)> = nmap.into_iter().collect();
+
+    let host_details = Arc::new(HostDetails {
+        ip_address: "45.33.32.156".parse().unwrap(),
+        status: HostStatus {
+            state: Up,
+            reason: "echo-reply".to_string(),
+            reason_ttl: 53,
+        },
+        host_names: vec![
+            Hostname {
+                name: "scanme.nmap.org".to_string(),
+                source: User,
+            },
+            Hostname {
+                name: "scanme.nmap.org".to_string(),
+                source: Dns,
+            },
+        ],
+        scan_start_time: 1_588_318_812,
+        scan_end_time: 1_588_318_814,
+    });
 
     let correct = vec![
         (
-            HostDetails {
-                ip_address: "45.33.32.156".parse().unwrap(),
-                status: HostStatus {
-                    state: HostState::Up,
-                    reason: "echo-reply".to_string(),
-                    reason_ttl: 53,
-                },
-                host_names: vec![
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: User,
-                    },
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: HostnameType::Dns,
-                    },
-                ],
-                scan_start_time: 1588318812,
-                scan_end_time: 1588318814,
-            },
+            host_details.clone(),
             Port {
-                protocol: PortProtocol::Tcp,
+                protocol: Tcp,
                 port_number: 22,
                 status: PortStatus {
-                    state: PortState::Open,
+                    state: Open,
                     reason: "syn-ack".to_string(),
                     reason_ttl: 53,
                 },
@@ -66,28 +69,9 @@ fn iter() {
             },
         ),
         (
-            HostDetails {
-                ip_address: "45.33.32.156".parse().unwrap(),
-                status: HostStatus {
-                    state: Up,
-                    reason: "echo-reply".to_string(),
-                    reason_ttl: 53,
-                },
-                host_names: vec![
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: HostnameType::User,
-                    },
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: HostnameType::Dns,
-                    },
-                ],
-                scan_start_time: 1588318812,
-                scan_end_time: 1588318814,
-            },
+            host_details.clone(),
             Port {
-                protocol: PortProtocol::Tcp,
+                protocol: Tcp,
                 port_number: 80,
                 status: PortStatus {
                     state: Open,
@@ -102,26 +86,7 @@ fn iter() {
             },
         ),
         (
-            HostDetails {
-                ip_address: "45.33.32.156".parse().unwrap(),
-                status: HostStatus {
-                    state: Up,
-                    reason: "echo-reply".to_string(),
-                    reason_ttl: 53,
-                },
-                host_names: vec![
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: User,
-                    },
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: Dns,
-                    },
-                ],
-                scan_start_time: 1588318812,
-                scan_end_time: 1588318814,
-            },
+            host_details.clone(),
             Port {
                 protocol: Tcp,
                 port_number: 9929,
@@ -138,26 +103,7 @@ fn iter() {
             },
         ),
         (
-            HostDetails {
-                ip_address: "45.33.32.156".parse().unwrap(),
-                status: HostStatus {
-                    state: Up,
-                    reason: "echo-reply".to_string(),
-                    reason_ttl: 53,
-                },
-                host_names: vec![
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: User,
-                    },
-                    Hostname {
-                        name: "scanme.nmap.org".to_string(),
-                        source: Dns,
-                    },
-                ],
-                scan_start_time: 1588318812,
-                scan_end_time: 1588318814,
-            },
+            host_details,
             Port {
                 protocol: Tcp,
                 port_number: 31337,

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -1,0 +1,181 @@
+#[macro_use]
+extern crate lazy_static;
+
+use nmap_xml_parser::host::*;
+use nmap_xml_parser::port::*;
+
+use nmap_xml_parser::{HostDetails, NmapResults, Port};
+use std::fs;
+use std::path::PathBuf;
+
+lazy_static! {
+    static ref NMAP: NmapResults = {
+        let mut path = PathBuf::new();
+        path.push(&std::env::var("CARGO_MANIFEST_DIR").unwrap());
+        path.push("tests/test.xml");
+        let content = fs::read_to_string(path).unwrap();
+        NmapResults::parse(&content).unwrap()
+    };
+}
+
+#[test]
+fn iter() {
+    use HostState::*;
+    use HostnameType::*;
+    use PortProtocol::*;
+    use PortState::*;
+    use ServiceMethod::*;
+    let nmap = NMAP.clone();
+    let vector: Vec<(HostDetails, Port)> = nmap.into_iter().collect();
+
+    let correct = vec![
+        (
+            HostDetails {
+                ip_address: "45.33.32.156".parse().unwrap(),
+                status: HostStatus {
+                    state: HostState::Up,
+                    reason: "echo-reply".to_string(),
+                    reason_ttl: 53,
+                },
+                host_names: vec![
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: User,
+                    },
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: HostnameType::Dns,
+                    },
+                ],
+                scan_start_time: 1588318812,
+                scan_end_time: 1588318814,
+            },
+            Port {
+                protocol: PortProtocol::Tcp,
+                port_number: 22,
+                status: PortStatus {
+                    state: PortState::Open,
+                    reason: "syn-ack".to_string(),
+                    reason_ttl: 53,
+                },
+                service_info: ServiceInfo {
+                    name: "ssh".to_string(),
+                    confidence_level: 3,
+                    method: Table,
+                },
+            },
+        ),
+        (
+            HostDetails {
+                ip_address: "45.33.32.156".parse().unwrap(),
+                status: HostStatus {
+                    state: Up,
+                    reason: "echo-reply".to_string(),
+                    reason_ttl: 53,
+                },
+                host_names: vec![
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: HostnameType::User,
+                    },
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: HostnameType::Dns,
+                    },
+                ],
+                scan_start_time: 1588318812,
+                scan_end_time: 1588318814,
+            },
+            Port {
+                protocol: PortProtocol::Tcp,
+                port_number: 80,
+                status: PortStatus {
+                    state: Open,
+                    reason: "syn-ack".to_string(),
+                    reason_ttl: 52,
+                },
+                service_info: ServiceInfo {
+                    name: "http".to_string(),
+                    confidence_level: 3,
+                    method: Table,
+                },
+            },
+        ),
+        (
+            HostDetails {
+                ip_address: "45.33.32.156".parse().unwrap(),
+                status: HostStatus {
+                    state: Up,
+                    reason: "echo-reply".to_string(),
+                    reason_ttl: 53,
+                },
+                host_names: vec![
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: User,
+                    },
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: Dns,
+                    },
+                ],
+                scan_start_time: 1588318812,
+                scan_end_time: 1588318814,
+            },
+            Port {
+                protocol: Tcp,
+                port_number: 9929,
+                status: PortStatus {
+                    state: Open,
+                    reason: "syn-ack".to_string(),
+                    reason_ttl: 53,
+                },
+                service_info: ServiceInfo {
+                    name: "nping-echo".to_string(),
+                    confidence_level: 3,
+                    method: Table,
+                },
+            },
+        ),
+        (
+            HostDetails {
+                ip_address: "45.33.32.156".parse().unwrap(),
+                status: HostStatus {
+                    state: Up,
+                    reason: "echo-reply".to_string(),
+                    reason_ttl: 53,
+                },
+                host_names: vec![
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: User,
+                    },
+                    Hostname {
+                        name: "scanme.nmap.org".to_string(),
+                        source: Dns,
+                    },
+                ],
+                scan_start_time: 1588318812,
+                scan_end_time: 1588318814,
+            },
+            Port {
+                protocol: Tcp,
+                port_number: 31337,
+                status: PortStatus {
+                    state: Open,
+                    reason: "syn-ack".to_string(),
+                    reason_ttl: 52,
+                },
+                service_info: ServiceInfo {
+                    name: "Elite".to_string(),
+                    confidence_level: 3,
+                    method: Table,
+                },
+            },
+        ),
+    ];
+
+    eprintln!("vector: {:?}", vector);
+
+    assert_eq!(vector, correct);
+}


### PR DESCRIPTION
I've written a preliminary implementation of `IntoIterator` for `NmapResults`, the idea being that if we can iterate over `(host, port)` then it'll be straightforward for an application to filter this for open ports, or ports that match a particular host or description.

It's currently nowhere near being efficient and makes liberal use of Clone on Vecs. Perhaps a better approach would be to wrap the hosts and ports Vecs in `Rc`s to reduce the number of allocations.

