### PR TITLE
"Down" hosts not parsed

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -59,8 +59,8 @@ impl Host {
 
         let status = status.ok_or_else(|| Error::from("expected `status` node for host"))?;
         let host_names =
-            host_names.ok_or_else(|| Error::from("expected `address` node for host"))?;
-        let port_info = port_info.ok_or_else(|| Error::from("expected `address` node for host"))?;
+            host_names.ok_or_else(|| Error::from("expected `hostnames` node for host"))?;
+        let port_info = port_info.ok_or_else(|| Error::from("expected `ports` node for host"))?;
 
         Ok(Host {
             scan_start_time,

--- a/src/host.rs
+++ b/src/host.rs
@@ -40,7 +40,7 @@ impl Host {
         };
 
         let mut status = None;
-        let mut host_names = None;
+        let mut host_names = Vec::new();
         let mut port_info = Default::default();
 
         let mut addresses = Vec::new();
@@ -49,15 +49,13 @@ impl Host {
             match child.tag_name().name() {
                 "address" => addresses.push(parse_address_node(child)?),
                 "status" => status = Some(HostStatus::parse(child)?),
-                "hostnames" => host_names = Some(parse_hostnames_node(child)?),
+                "hostnames" => host_names = parse_hostnames_node(child)?,
                 "ports" => port_info = PortInfo::parse(child)?,
                 _ => {}
             }
         }
 
         let status = status.ok_or_else(|| Error::from("expected `status` node for host"))?;
-        let host_names =
-            host_names.ok_or_else(|| Error::from("expected `hostnames` node for host"))?;
 
         Ok(Host {
             scan_start_time,

--- a/src/host.rs
+++ b/src/host.rs
@@ -25,21 +25,19 @@ pub struct Host {
 
 impl Host {
     pub(crate) fn parse(node: Node) -> Result<Self, Error> {
-        let scan_start_time = node
-            .attribute("starttime")
-            .ok_or_else(|| Error::from("expected `starttime` attribute in `host` node"))
-            .and_then(|s| {
-                s.parse::<i64>()
-                    .or_else(|_| Err(Error::from("failed to parse host start time")))
-            })?;
+        let scan_start_time = if let Some(s) = node.attribute("starttime") {
+            s.parse::<i64>()
+                .or_else(|_| Err(Error::from("failed to parse host start time")))?
+        } else {
+            0
+        };
 
-        let scan_end_time = node
-            .attribute("endtime")
-            .ok_or_else(|| Error::from("expected `endtime` attribute in `host` node"))
-            .and_then(|s| {
-                s.parse::<i64>()
-                    .or_else(|_| Err(Error::from("failed to parse host end time")))
-            })?;
+        let scan_end_time = if let Some(s) = node.attribute("endtime") {
+            s.parse::<i64>()
+                .or_else(|_| Err(Error::from("failed to parse host end time")))?
+        } else {
+            0
+        };
 
         let mut status = None;
         let mut host_names = None;

--- a/src/host.rs
+++ b/src/host.rs
@@ -41,7 +41,7 @@ impl Host {
 
         let mut status = None;
         let mut host_names = None;
-        let mut port_info = None;
+        let mut port_info = Default::default();
 
         let mut addresses = Vec::new();
 
@@ -50,7 +50,7 @@ impl Host {
                 "address" => addresses.push(parse_address_node(child)?),
                 "status" => status = Some(HostStatus::parse(child)?),
                 "hostnames" => host_names = Some(parse_hostnames_node(child)?),
-                "ports" => port_info = Some(PortInfo::parse(child)?),
+                "ports" => port_info = PortInfo::parse(child)?,
                 _ => {}
             }
         }
@@ -58,7 +58,6 @@ impl Host {
         let status = status.ok_or_else(|| Error::from("expected `status` node for host"))?;
         let host_names =
             host_names.ok_or_else(|| Error::from("expected `hostnames` node for host"))?;
-        let port_info = port_info.ok_or_else(|| Error::from("expected `ports` node for host"))?;
 
         Ok(Host {
             scan_start_time,

--- a/src/port.rs
+++ b/src/port.rs
@@ -5,7 +5,7 @@ use strum_macros::{Display, EnumString};
 
 use crate::Error;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PortInfo {
     pub(crate) ports: Vec<Port>,
 }

--- a/tests/host-down.xml
+++ b/tests/host-down.xml
@@ -9,16 +9,16 @@
 <taskbegin task="ARP Ping Scan" time="1592485655"/>
 <taskend task="ARP Ping Scan" time="1592485655" extrainfo="4 total hosts"/>
 <host><status state="down" reason="no-response" reason_ttl="0"/>
-<address addr="192.168.59.232" addrtype="ipv4"/><hostnames/>
+<address addr="192.168.59.232" addrtype="ipv4"/>
 </host>
 <host><status state="down" reason="no-response" reason_ttl="0"/>
-<address addr="192.168.59.233" addrtype="ipv4"/><hostnames/>
+<address addr="192.168.59.233" addrtype="ipv4"/>
 </host>
 <host><status state="down" reason="no-response" reason_ttl="0"/>
-<address addr="192.168.59.234" addrtype="ipv4"/><hostnames/>
+<address addr="192.168.59.234" addrtype="ipv4"/>
 </host>
 <host><status state="down" reason="no-response" reason_ttl="0"/>
-<address addr="192.168.59.235" addrtype="ipv4"/><hostnames/>
+<address addr="192.168.59.235" addrtype="ipv4"/>
 </host>
 <runstats><finished time="1592485655" timestr="Thu Jun 18 14:07:35 2020" elapsed="0.58" summary="Nmap done at Thu Jun 18 14:07:35 2020; 4 IP addresses (0 hosts up) scanned in 0.58 seconds" exit="success"/><hosts up="0" down="4" total="4"/>
 </runstats>

--- a/tests/host-down.xml
+++ b/tests/host-down.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
+<!-- Nmap 7.80 scan initiated Thu Jun 18 14:07:35 2020 as: nmap -p 1234 -oX host-down.xml -v 192.168.59.234/30 -->
+<nmaprun scanner="nmap" args="nmap -p 1234 -oX host-down.xml -v 192.168.59.234/30" start="1592485655" startstr="Thu Jun 18 14:07:35 2020" version="7.80" xmloutputversion="1.04">
+<scaninfo type="syn" protocol="tcp" numservices="1" services="1234"/>
+<verbose level="1"/>
+<debugging level="0"/>
+<taskbegin task="ARP Ping Scan" time="1592485655"/>
+<taskend task="ARP Ping Scan" time="1592485655" extrainfo="4 total hosts"/>
+<host><status state="down" reason="no-response" reason_ttl="0"/>
+<address addr="192.168.59.232" addrtype="ipv4"/><hostnames/>
+</host>
+<host><status state="down" reason="no-response" reason_ttl="0"/>
+<address addr="192.168.59.233" addrtype="ipv4"/><hostnames/>
+</host>
+<host><status state="down" reason="no-response" reason_ttl="0"/>
+<address addr="192.168.59.234" addrtype="ipv4"/><hostnames/>
+</host>
+<host><status state="down" reason="no-response" reason_ttl="0"/>
+<address addr="192.168.59.235" addrtype="ipv4"/><hostnames/>
+</host>
+<runstats><finished time="1592485655" timestr="Thu Jun 18 14:07:35 2020" elapsed="0.58" summary="Nmap done at Thu Jun 18 14:07:35 2020; 4 IP addresses (0 hosts up) scanned in 0.58 seconds" exit="success"/><hosts up="0" down="4" total="4"/>
+</runstats>
+</nmaprun>

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -47,13 +47,13 @@ fn end_time() {
 #[test]
 fn host_start_time() {
     let host = NMAP_TEST_XML.hosts().next().unwrap();
-    assert_eq!(host.scan_start_time, 1588318812);
+    assert_eq!(host.scan_start_time, Some(1588318812));
 }
 
 #[test]
 fn host_end_time() {
     let host = NMAP_TEST_XML.hosts().next().unwrap();
-    assert_eq!(host.scan_end_time, 1588318814);
+    assert_eq!(host.scan_end_time, Some(1588318814));
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,6 +20,13 @@ lazy_static! {
         let content = fs::read_to_string(path).unwrap();
         NmapResults::parse(&content).unwrap()
     };
+    static ref NMAP_HOST_DOWN: NmapResults = {
+        let mut path = PathBuf::new();
+        path.push(&std::env::var("CARGO_MANIFEST_DIR").unwrap());
+        path.push("tests/host-down.xml");
+        let content = fs::read_to_string(path).unwrap();
+        NmapResults::parse(&content).unwrap()
+    };
 }
 
 fn vectors_eq<T: PartialEq>(a: &Vec<T>, b: &Vec<T>) -> bool {
@@ -203,4 +210,14 @@ fn test_iter_ports() {
 
     let expected = vec![22, 80, 9929, 31337];
     assert!(vectors_eq(&v, &expected));
+}
+
+#[test]
+fn test_host_down() {
+    use host::HostState;
+    eprintln!("{:?}", *NMAP_HOST_DOWN);
+
+    for host in NMAP_HOST_DOWN.hosts() {
+        assert_eq!(host.status.state, HostState::Down);
+    }
 }


### PR DESCRIPTION
When running nmap with `-v` it stores "down" hosts in the XML output, but these do not have `starttime`, `endtime` or `ports` fields. I've set the start and end times to default to `0` if these are missing, and set the ports field to default to an empty list of ports.

I've also added this XML file as an integration test:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE nmaprun>
<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
<!-- Nmap 7.80 scan initiated Thu Jun 18 14:07:35 2020 as: nmap -p 1234 -oX host-down.xml -v 192.168.59.234/30 -->
<nmaprun scanner="nmap" args="nmap -p 1234 -oX host-down.xml -v 192.168.59.234/30" start="1592485655" startstr="Thu Jun 18 14:07:35 2020" version="7.80" xmloutputversion="1.04">
<scaninfo type="syn" protocol="tcp" numservices="1" services="1234"/>
<verbose level="1"/>
<debugging level="0"/>
<taskbegin task="ARP Ping Scan" time="1592485655"/>
<taskend task="ARP Ping Scan" time="1592485655" extrainfo="4 total hosts"/>
<host><status state="down" reason="no-response" reason_ttl="0"/>
<address addr="192.168.59.232" addrtype="ipv4"/>
</host>
<host><status state="down" reason="no-response" reason_ttl="0"/>
<address addr="192.168.59.233" addrtype="ipv4"/>
</host>
<host><status state="down" reason="no-response" reason_ttl="0"/>
<address addr="192.168.59.234" addrtype="ipv4"/>
</host>
<host><status state="down" reason="no-response" reason_ttl="0"/>
<address addr="192.168.59.235" addrtype="ipv4"/>
</host>
<runstats><finished time="1592485655" timestr="Thu Jun 18 14:07:35 2020" elapsed="0.58" summary="Nmap done at Thu Jun 18 14:07:35 2020; 4 IP addresses (0 hosts up) scanned in 0.58 seconds" exit="success"/><hosts up="0" down="4" total="4"/>
</runstats>
</nmaprun>
```