### PR TITLE
Some parsing macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ roxmltree = "0.11.0"
 thiserror = "1.0.16"
 strum = "0.18.0"
 strum_macros = "0.18.0"
+const_format = "0.2.26"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/src/host.rs
+++ b/src/host.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
 use crate::port::PortInfo;
-use crate::util::{node_attr_as_string, parse_node_attr};
+use crate::util::{from_node_attr, node_attr_as_string, parse_node_attr};
 use crate::Error;
 
 #[derive(Display, Clone, Debug, PartialEq)]
@@ -189,7 +189,6 @@ pub struct Hostname {
 
 impl Hostname {
     fn parse(node: Node) -> Result<Self, Error> {
-
         let name = node_attr_as_string!(node, "hostname", "name");
 
         let s = node
@@ -210,7 +209,6 @@ pub struct Script {
 
 impl Script {
     fn parse(node: Node) -> Result<Self, Error> {
-
         let id = node_attr_as_string!(node, "script", "id");
 
         let output = node_attr_as_string!(node, "script", "output");

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,10 +1,12 @@
 //!Host related structs and enums.
+use const_format::formatcp;
 use roxmltree::Node;
 use std::net::IpAddr;
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
 use crate::port::PortInfo;
+use crate::util::{node_attr_as_string, parse_node_attr};
 use crate::Error;
 
 #[derive(Display, Clone, Debug, PartialEq)]

--- a/src/host.rs
+++ b/src/host.rs
@@ -143,15 +143,11 @@ pub struct HostStatus {
 
 impl HostStatus {
     fn parse(node: Node) -> Result<Self, Error> {
-        let s = node
-            .attribute("state")
-            .ok_or_else(|| Error::from("expected `state` attribute in `hoststatus` node"))?;
-        let state =
-            HostState::from_str(s).map_err(|_| Error::from("failed to parse host state"))?;
+        let state = from_node_attr!(node, "hoststatus", "state", HostState);
 
         let reason = node_attr_as_string!(node, "hoststatus", "reason");
 
-        let reason_ttl = parse_node_attr!(node, "hoststatus", "reason_ttl", u8)?;
+        let reason_ttl = parse_node_attr!(node, "hoststatus", "reason_ttl", u8);
 
         Ok(HostStatus {
             state,
@@ -191,11 +187,7 @@ impl Hostname {
     fn parse(node: Node) -> Result<Self, Error> {
         let name = node_attr_as_string!(node, "hostname", "name");
 
-        let s = node
-            .attribute("type")
-            .ok_or_else(|| Error::from("expected `type` attribute in `hostname` node"))?;
-        let source = HostnameType::from_str(s)
-            .map_err(|_| Error::from("expected `source` attribute in `address` node"))?;
+        let source = from_node_attr!(node, "hostname", "type", HostnameType);
 
         Ok(Hostname { name, source })
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -149,18 +149,9 @@ impl HostStatus {
         let state =
             HostState::from_str(s).map_err(|_| Error::from("failed to parse host state"))?;
 
-        let reason = node
-            .attribute("reason")
-            .ok_or_else(|| Error::from("expected `reason` attribute in `hoststatus` node"))?
-            .to_string();
+        let reason = node_attr_as_string!(node, "hoststatus", "reason");
 
-        let reason_ttl = node
-            .attribute("reason_ttl")
-            .ok_or_else(|| Error::from("expected `reason_ttl` attribute in `hoststatus` node"))
-            .and_then(|s| {
-                s.parse::<u8>()
-                    .map_err(|_| Error::from("failed to parse `reason_ttl`"))
-            })?;
+        let reason_ttl = parse_node_attr!(node, "hoststatus", "reason_ttl", u8)?;
 
         Ok(HostStatus {
             state,
@@ -198,10 +189,8 @@ pub struct Hostname {
 
 impl Hostname {
     fn parse(node: Node) -> Result<Self, Error> {
-        let name = node
-            .attribute("name")
-            .ok_or_else(|| Error::from("expected `name` attribute in `hostname` node"))?
-            .to_string();
+
+        let name = node_attr_as_string!(node, "hostname", "name");
 
         let s = node
             .attribute("type")
@@ -221,15 +210,10 @@ pub struct Script {
 
 impl Script {
     fn parse(node: Node) -> Result<Self, Error> {
-        let id = node
-            .attribute("id")
-            .ok_or_else(|| Error::from("expected `id` attribute in `script` node"))?
-            .to_string();
 
-        let output = node
-            .attribute("output")
-            .ok_or_else(|| Error::from("expected `output` attribute in `script` node"))?
-            .to_string();
+        let id = node_attr_as_string!(node, "script", "id");
+
+        let output = node_attr_as_string!(node, "script", "output");
 
         Ok(Script { id, output })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use roxmltree::{Document, Node};
 
 pub mod host;
 pub mod port;
+pub mod util;
 
 use crate::host::Host;
 use crate::port::Port;

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,11 +1,11 @@
 //!Port related structs and enums.
+use const_format::formatcp;
 use roxmltree::Node;
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
-use const_format::formatcp;
 
+use crate::util::{node_attr_as_string, parse_node_attr};
 use crate::Error;
-use crate::util::{parse_node_attr, node_attr_as_string};
 
 #[derive(Clone, Debug, Default)]
 pub struct PortInfo {

--- a/src/port.rs
+++ b/src/port.rs
@@ -4,7 +4,7 @@ use roxmltree::Node;
 use std::str::FromStr;
 use strum_macros::{Display, EnumString};
 
-use crate::util::{node_attr_as_string, parse_node_attr};
+use crate::util::{from_node_attr, node_attr_as_string, parse_node_attr};
 use crate::Error;
 
 #[derive(Clone, Debug, Default)]
@@ -43,13 +43,9 @@ pub struct Port {
 
 impl Port {
     fn parse(node: Node) -> Result<Self, Error> {
-        let s = node
-            .attribute("protocol")
-            .ok_or_else(|| Error::from("expected `protocol` attribute in `port` node"))?;
-        let protocol =
-            PortProtocol::from_str(s).map_err(|_| Error::from("failed to parse port protocol"))?;
+        let protocol = from_node_attr!(node, "port", "protocol", PortProtocol);
 
-        let port_number = parse_node_attr!(node, "port", "portid", u16)?;
+        let port_number = parse_node_attr!(node, "port", "portid", u16);
 
         let mut status = None;
         let mut service_info = None;
@@ -94,15 +90,11 @@ pub struct PortStatus {
 
 impl PortStatus {
     fn parse(node: Node) -> Result<Self, Error> {
-        let s = node
-            .attribute("state")
-            .ok_or_else(|| Error::from("expected `state` attribute for port"))?;
-        let state =
-            PortState::from_str(s).map_err(|_| Error::from("failed to parse port state"))?;
+        let state = from_node_attr!(node, "port", "state", PortState);
 
         let reason = node_attr_as_string!(node, "port", "reason");
 
-        let reason_ttl = parse_node_attr!(node, "port", "reason_ttl", u8)?;
+        let reason_ttl = parse_node_attr!(node, "port", "reason_ttl", u8);
 
         Ok(PortStatus {
             state,
@@ -139,13 +131,9 @@ impl ServiceInfo {
     fn parse(node: Node) -> Result<Self, Error> {
         let name = node_attr_as_string!(node, "service", "name");
 
-        let confidence_level = parse_node_attr!(node, "service", "conf", u8)?;
+        let confidence_level = parse_node_attr!(node, "service", "conf", u8);
 
-        let s = node
-            .attribute("method")
-            .ok_or_else(|| Error::from("expected `method` attribute for service"))?;
-        let method = ServiceMethod::from_str(s)
-            .map_err(|_| Error::from("failed to parse service method"))?;
+        let method = from_node_attr!(node, "service", "method", ServiceMethod);
 
         Ok(ServiceInfo {
             name,

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,7 +20,7 @@ macro_rules! parse_node_attr {
 
 macro_rules! node_attr_as_string {
     ($node:expr, $nodename:expr, $attribute:expr) => {{
-        Ok($node
+        $node
             .attribute($attribute)
             .ok_or_else(|| {
                 Error::from(formatcp!(
@@ -29,7 +29,7 @@ macro_rules! node_attr_as_string {
                     $nodename
                 ))
             })?
-            .to_string())
+            .to_string()
     }};
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,37 @@
+use const_format::formatcp;
+
+macro_rules! parse_node_attr {
+    ($node:expr, $nodename:expr, $attribute:expr, $type:ty) => {{
+        $node
+            .attribute($attribute)
+            .ok_or_else(|| {
+                Error::from(formatcp!(
+                    "expected `{}` attribute in `{}`",
+                    $attribute,
+                    $nodename
+                ))
+            })
+            .and_then(|s| {
+                s.parse::<$type>()
+                    .map_err(|_| Error::from(formatcp!("failed to parse `{}`", $attribute)))
+            })
+    }};
+}
+
+macro_rules! node_attr_as_string {
+    ($node:expr, $nodename:expr, $attribute:expr) => {{
+        Ok($node
+            .attribute($attribute)
+            .ok_or_else(|| {
+                Error::from(formatcp!(
+                    "expected `{}` attribute in `{}` node",
+                    $attribute,
+                    $nodename
+                ))
+            })?
+            .to_string())
+    }};
+}
+
+pub(crate) use node_attr_as_string;
+pub(crate) use parse_node_attr;

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,7 +41,7 @@ macro_rules! from_node_attr {
             ))
         })?;
         <$type>::from_str(s)
-            .map_err(|_| Error::from(formatcp!("failed to parse {}", stringify!($type))))?
+            .map_err(|_| Error::from(formatcp!("failed to parse `{}`", stringify!($type))))?
     }};
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,7 +14,7 @@ macro_rules! parse_node_attr {
             .and_then(|s| {
                 s.parse::<$type>()
                     .map_err(|_| Error::from(formatcp!("failed to parse `{}`", $attribute)))
-            })
+            })?
     }};
 }
 
@@ -42,7 +42,8 @@ macro_rules! from_node_attr {
                 $nodename
             ))
         })?;
-        $type::from_str(s).map_err(|_| Error::from(formatcp!("failed to parse {}", $attribute)))?;
+        <$type>::from_str(s)
+            .map_err(|_| Error::from(formatcp!("failed to parse {}", stringify!($type))))?
     }};
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -33,5 +33,19 @@ macro_rules! node_attr_as_string {
     }};
 }
 
+macro_rules! from_node_attr {
+    ($node:expr, $nodename:expr, $attribute:expr, $type:ty) => {{
+        let s = $node.attribute($attribute).ok_or_else(|| {
+            Error::from(formatcp!(
+                "expected `{}` attribute in `{}` node",
+                $attribute,
+                $nodename
+            ))
+        })?;
+        $type::from_str(s).map_err(|_| Error::from(formatcp!("failed to parse {}", $attribute)))?;
+    }};
+}
+
+pub(crate) use from_node_attr;
 pub(crate) use node_attr_as_string;
 pub(crate) use parse_node_attr;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,3 @@
-use const_format::formatcp;
-
 macro_rules! parse_node_attr {
     ($node:expr, $nodename:expr, $attribute:expr, $type:ty) => {{
         $node


### PR DESCRIPTION
Added some macros for parsing node attributes and replaced the relevant boilerplate in the existing codebase.
These should make writing new code easier.